### PR TITLE
2022 04 25

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -115,6 +115,18 @@ export default class New extends Command {
     }
     fs.ensureDirSync(site)
 
+    const {owner: bedrockRemoteOwner, repo: bedrockRemoteRepo} = await git.parseRemote(bedrock_remote)
+    const {owner: trellisRemoteOwner, repo: trellisRemoteRepo} = await git.parseRemote(trellis_remote)
+    if (github) {
+      cli.action.start('Creating Bedrock repo on GitHub')
+      await gh.createRepo(bedrockRemoteOwner, bedrockRemoteRepo)
+      cli.action.stop()
+
+      cli.action.start('Creating Trellis repo on GitHub')
+      await gh.createRepo(trellisRemoteOwner, trellisRemoteRepo)
+      cli.action.stop()
+    }
+
     cli.action.start('Cloning Bedrock template repo')
     await git.clone(bedrock_template_remote, {
       dir: 'bedrock',
@@ -311,7 +323,6 @@ export default class New extends Command {
       cli.action.stop()
 
       cli.action.start('Setting Bedrock repo deploy key')
-      const {owner: bedrockRemoteOwner, repo: bedrockRemoteRepo} = await git.parseRemote(bedrock_remote)
       await gh.setDeployKey(deployKey.public, keyName, bedrockRemoteOwner, bedrockRemoteRepo)
       cli.action.stop()
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -125,7 +125,7 @@ export default class New extends Command {
     }, {
       cwd: site,
     })
-    await git.renameCurrentBranch('master', {
+    await git.renameCurrentBranch('main', {
       cwd: `${site}/bedrock`,
     })
     await git.removeRemote('upstream', {
@@ -144,7 +144,7 @@ export default class New extends Command {
     }, {
       cwd: site,
     })
-    await git.renameCurrentBranch('master', {
+    await git.renameCurrentBranch('main', {
       cwd: `${site}/trellis`,
     })
     await git.removeRemote('upstream', {
@@ -287,19 +287,19 @@ export default class New extends Command {
 
     if (git_push) {
       cli.action.start('Pushing Trellis changes to new repo')
-      await git.push('origin', 'master', {
+      await git.push('origin', 'main', {
         cwd: `${site}/trellis`,
       })
       cli.action.stop()
 
       cli.action.start('Pushing Bedrock changes to new repo')
-      await git.push('origin', 'master', {
+      await git.push('origin', 'main', {
         cwd: `${site}/bedrock`,
       })
-      await git.push('origin', 'master:staging', {
+      await git.push('origin', 'main:staging', {
         cwd: `${site}/bedrock`,
       })
-      await git.push('origin', 'master:production', {
+      await git.push('origin', 'main:production', {
         cwd: `${site}/bedrock`,
       })
       cli.action.stop()

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -53,8 +53,8 @@ export default class New extends Command {
       default: true,
       allowNo: true,
     }),
-    gh_set_repo_secrets: flags.boolean({
-      description: 'whether to set repository secrets or not',
+    github: flags.boolean({
+      description: 'whether to use GH CLI/API or not',
       default: true,
       allowNo: true,
       dependsOn: ['git_push'],
@@ -68,7 +68,7 @@ export default class New extends Command {
     bedrock_repo_pat: flags.string({
       description: 'the bedrock personal access token for GitHub Actions to clone trellis',
       env: 'IROOTS_NEW_BEDROCK_REPO_PAT',
-      dependsOn: ['gh_set_repo_secrets'],
+      dependsOn: ['github'],
       required: true,
     }),
     trellis_remote: flags.string({
@@ -110,7 +110,7 @@ export default class New extends Command {
 
   async run(): Promise<void> {
     const {flags} = this.parse(New)
-    const {site, deploy, local, git_push, gh_set_repo_secrets, bedrock_remote, trellis_remote, bedrock_repo_pat, bedrock_template_remote, bedrock_template_branch, trellis_template_remote, trellis_template_branch, trellis_template_vault_pass} = flags
+    const {site, deploy, local, git_push, github, bedrock_remote, trellis_remote, bedrock_repo_pat, bedrock_template_remote, bedrock_template_branch, trellis_template_remote, trellis_template_branch, trellis_template_vault_pass} = flags
 
     if (fs.existsSync(site)) {
       this.error(`Abort! Directory ${site} already exists`, {exit: 1})
@@ -121,7 +121,7 @@ export default class New extends Command {
     await git.clone(bedrock_template_remote, {
       dir: 'bedrock',
       branch: bedrock_template_branch,
-      origin: 'upstream'
+      origin: 'upstream',
     }, {
       cwd: site,
     })
@@ -305,7 +305,7 @@ export default class New extends Command {
       cli.action.stop()
     }
 
-    if (gh_set_repo_secrets) {
+    if (github) {
       cli.action.start('Generating Bedrock repo deploy key')
       const keyName = 'Trellis deploy'
       const keyFilePath = `${homedir()}/.ssh/trellis_${site}_ed25519`

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -446,5 +446,10 @@ export default class New extends Command {
       })
       cli.action.stop()
     }
+
+    if (github) {
+      cli.info('Don\'t forget to set your branch protection rules for `main`!')
+      cli.info('Without branch protection on `main`, Kodiak will not merge any dependency pull requests.')
+    }
   }
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -57,7 +57,6 @@ export default class New extends Command {
       description: 'whether to use GH CLI/API or not',
       default: true,
       allowNo: true,
-      dependsOn: ['git_push'],
     }),
     bedrock_remote: flags.string({
       char: 'b',
@@ -68,7 +67,6 @@ export default class New extends Command {
     bedrock_repo_pat: flags.string({
       description: 'the bedrock personal access token for GitHub Actions to clone trellis',
       env: 'IROOTS_NEW_BEDROCK_REPO_PAT',
-      dependsOn: ['github'],
       required: true,
     }),
     trellis_remote: flags.string({

--- a/src/lib/gh.ts
+++ b/src/lib/gh.ts
@@ -9,5 +9,9 @@ export async function setDeployKey(key: string, keyName: string, owner: string, 
 }
 
 export async function createRepo(owner: string, repo: string, options?: execa.Options) {
-  return execa('gh', ['repo', 'create', `${owner}/${repo}`, '--private'], options)
+  return execa('gh', ['repo', 'create', `${owner}/${repo}`, '--private', '--team', 'php-team'], options)
+}
+
+export async function editRepo(owner: string, repo: string, flag: string, options?: execa.Options) {
+  return execa('gh', ['repo', 'edit', `${owner}/${repo}`, `--${flag}`], options)
 }

--- a/src/lib/gh.ts
+++ b/src/lib/gh.ts
@@ -7,3 +7,7 @@ export async function setSecret(key: string, value: string, repo: string, option
 export async function setDeployKey(key: string, keyName: string, owner: string, repo: string, options?: execa.Options) {
   return execa('gh', ['api', `repos/${owner}/${repo}/keys`, '-f', `title=${keyName}`, '-f', `key=${key}`, '-f', 'read_only=true'], options)
 }
+
+export async function createRepo(owner: string, repo: string, options?: execa.Options) {
+  return execa('gh', ['repo', 'create', `${owner}/${repo}`, '--private'], options)
+}

--- a/src/lib/gh.ts
+++ b/src/lib/gh.ts
@@ -8,10 +8,14 @@ export async function setDeployKey(key: string, keyName: string, owner: string, 
   return execa('gh', ['api', `repos/${owner}/${repo}/keys`, '-f', `title=${keyName}`, '-f', `key=${key}`, '-f', 'read_only=true'], options)
 }
 
-export async function createRepo(owner: string, repo: string, options?: execa.Options) {
-  return execa('gh', ['repo', 'create', `${owner}/${repo}`, '--private', '--team', 'php-team'], options)
+export async function createRepo(owner: string, repo: string, {teamSlug = 'php-team'}, options?: execa.Options) {
+  return execa('gh', ['repo', 'create', `${owner}/${repo}`, '--private', '--team', teamSlug], options)
 }
 
 export async function editRepo(owner: string, repo: string, flag: string, options?: execa.Options) {
   return execa('gh', ['repo', 'edit', `${owner}/${repo}`, `--${flag}`], options)
+}
+
+export async function setTeamPermissions(owner: string, repo: string, {teamSlug = 'php-team', teamPermission = 'admin'}, options?: execa.Options) {
+  return execa('gh', ['api', '--method', 'PUT', '-H', 'Accept: application/vnd.github.v3+json', `orgs/${owner}/teams/${teamSlug}/repos/${owner}/${repo}`, '-f', `permission=${teamPermission}`], options)
 }

--- a/src/lib/wp.ts
+++ b/src/lib/wp.ts
@@ -1,5 +1,12 @@
 import * as execa from 'execa'
+import cli from 'cli-ux'
 
 export async function dbCreate(options?: execa.Options) {
-  return execa('wp', ['db', 'create'], options)
+  try {
+    await execa('wp', ['db', 'create'], options)
+    return true
+  } catch (error) {
+    cli.log(error.stderr.substring(error.stdout.indexOf(': ') + 1))
+    return false
+  }
 }

--- a/src/lib/wp.ts
+++ b/src/lib/wp.ts
@@ -1,5 +1,5 @@
-import * as execa from 'execa'
 import cli from 'cli-ux'
+import * as execa from 'execa'
 
 export async function dbCreate(options?: execa.Options) {
   try {


### PR DESCRIPTION
- 🔧(git): use new `main` default branch
- 🔨(gh): `gh_set_repo_secrets` -> `github`
- 🐛(wp): could not pass `dbCreate`
- ✨(gh): create GitHub repos
- ✨(gh): add `editRepo` function
- ✨(gh): automate repo creation
- ✨(gh): add some helpful finishing info
- ✨(git): configurable flags
