### PR TITLE
npm remove @types/globby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@oclif/test": "^4",
         "@types/chai": "^5",
         "@types/fs-extra": "^11.0.4",
-        "@types/globby": "^9.1.0",
         "@types/node": "^24",
         "chai": "^5",
         "eslint": "^9",
@@ -3012,16 +3011,6 @@
       "dependencies": {
         "@types/jsonfile": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/globby": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@types/globby/-/globby-9.1.0.tgz",
-      "integrity": "sha512-9du/HCA71EBz7syHRnM4Q/u4Fbx3SyN/Uu+4Of9lyPX4A6Xi+A8VMxvx8j5/CMTfrae2Zwdwg0fAaKvKXfRbAw==",
-      "deprecated": "This is a stub types definition. globby provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "globby": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@oclif/test": "^4",
     "@types/chai": "^5",
     "@types/fs-extra": "^11.0.4",
-    "@types/globby": "^9.1.0",
     "@types/node": "^24",
     "chai": "^5",
     "eslint": "^9",


### PR DESCRIPTION
globby provides its own types now
