### PR TITLE
feat: add missing fields to KinstaEnvironment type

### DIFF
--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -18,16 +18,25 @@ type KinstaDomain = {
   type: string
 }
 
+type KinstaContainerInfo = {
+  id: string
+  php_engine_version: string
+}
+
 type KinstaEnvironment = {
-  cdn_cache_id?: string
+  cdn_cache_id?: null | string
+  container_info: KinstaContainerInfo
 
   display_name: string
   domains: KinstaDomain[]
   id: string
 
-  id_edge_cache?: string
+  id_edge_cache?: null | string
+  image_optimization_type?: null | string
+  is_additional_sftp_accounts_enabled: boolean
 
   is_blocked: boolean
+  is_opt_out_from_automatic_php_update?: boolean | null
 
   is_premium: boolean
   name: string
@@ -40,6 +49,9 @@ type KinstaEnvironment = {
 
     ssh_port: number
   }
+
+  web_root?: string
+  wordpress_version?: null | string
 }
 
 export type KinstaSite = {


### PR DESCRIPTION
## Summary

Add missing fields to the `KinstaEnvironment` type to match the Kinsta API v2 response schema. This enables access to `container_info.php_engine_version` and other environment metadata when listing sites with `--include_environments`.

## Changes

- Add `KinstaContainerInfo` type with `id` and `php_engine_version` fields
- Add `container_info`, `web_root`, `wordpress_version`, `image_optimization_type`, `is_additional_sftp_accounts_enabled`, and `is_opt_out_from_automatic_php_update` to `KinstaEnvironment`
- Fix nullable types for `cdn_cache_id` and `id_edge_cache` to match API spec

## Testing

- `npm run lint` passes
- `npm run build` passes
- Run `iroots kinsta sites list --include_environments --format=json | jq '.[0].environments[0].container_info'` to verify the field is accessible
