### PR TITLE
fix: guard against undefined kinstaError.data in request()

### DIFF
--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -209,34 +209,8 @@ export async function getSite(token: string, siteId: string): Promise<KinstaSite
 }
 
 export async function getSiteEnvironments(token: string, siteId: string): Promise<KinstaEnvironment[]> {
-  try {
-    const response = await request<KinstaEnvironmentsRequest>(token, `sites/${siteId}/environments`)
-    return response.site.environments
-  } catch {
-    // Environments endpoint may fail with 500 when site is blocked (busy)
-    // Fall back to polling the site endpoint until unblocked
-    const maxAttempts = 12 // 12 * 10s = 2 minutes
-
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      // eslint-disable-next-line no-await-in-loop
-      const siteResponse = await request<KinstaSiteRequest>(token, `sites/${siteId}`)
-      const environments: KinstaEnvironment[] = siteResponse.site.environments ?? []
-      const anyBlocked = environments.some((env: KinstaEnvironment) => env.is_blocked)
-
-      if (!anyBlocked) {
-        return environments
-      }
-
-      // Site is blocked (busy), wait and retry
-      ux.warn(`Site is busy (attempt ${attempt}/${maxAttempts}), waiting 10s...`)
-      // eslint-disable-next-line no-await-in-loop
-      await wait(10_000)
-    }
-
-    // Timeout — return whatever we have (environments exist but site is blocked)
-    const finalResponse = await request<KinstaSiteRequest>(token, `sites/${siteId}`)
-    return finalResponse.site.environments ?? []
-  }
+  const response = await request<KinstaEnvironmentsRequest>(token, `sites/${siteId}/environments`)
+  return response.site.environments
 }
 
 type KinstaCloneEnvironmentArgs = {

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -168,19 +168,12 @@ async function request<TResponse>(token: string, url: string, options: RequestIn
 
   if ([400, 401, 404, 500].includes(statusCode)) {
     const kinstaError: KinstaError = data
-    if (kinstaError.error) {
-      ux.error(kinstaError.error)
-    }
+    const errorMessage = kinstaError.error
+      || kinstaError.data?.message
+      || kinstaError.message
+      || JSON.stringify(data)
 
-    if (data?.status === 500 && kinstaError.data?.message) {
-      ux.error(kinstaError.data.message)
-    }
-
-    if (kinstaError.message) {
-      ux.error(kinstaError.message)
-    }
-
-    ux.error(`Kinsta API error (${statusCode}): ${JSON.stringify(data)}`)
+    ux.error(`Kinsta API error (${statusCode}) on ${url}: ${errorMessage}`)
   }
 
   // The response is still in progress, wait until it is finished.

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -209,9 +209,34 @@ export async function getSite(token: string, siteId: string): Promise<KinstaSite
 }
 
 export async function getSiteEnvironments(token: string, siteId: string): Promise<KinstaEnvironment[]> {
-  const response = await request<KinstaEnvironmentsRequest>(token, `sites/${siteId}/environments`)
+  try {
+    const response = await request<KinstaEnvironmentsRequest>(token, `sites/${siteId}/environments`)
+    return response.site.environments
+  } catch {
+    // Environments endpoint may fail with 500 when site is blocked (busy)
+    // Fall back to polling the site endpoint until unblocked
+    const maxAttempts = 12 // 12 * 10s = 2 minutes
 
-  return response.site.environments
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      // eslint-disable-next-line no-await-in-loop
+      const siteResponse = await request<KinstaSiteRequest>(token, `sites/${siteId}`)
+      const environments: KinstaEnvironment[] = siteResponse.site.environments ?? []
+      const anyBlocked = environments.some((env: KinstaEnvironment) => env.is_blocked)
+
+      if (!anyBlocked) {
+        return environments
+      }
+
+      // Site is blocked (busy), wait and retry
+      ux.warn(`Site is busy (attempt ${attempt}/${maxAttempts}), waiting 10s...`)
+      // eslint-disable-next-line no-await-in-loop
+      await wait(10_000)
+    }
+
+    // Timeout — return whatever we have (environments exist but site is blocked)
+    const finalResponse = await request<KinstaSiteRequest>(token, `sites/${siteId}`)
+    return finalResponse.site.environments ?? []
+  }
 }
 
 type KinstaCloneEnvironmentArgs = {

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -114,7 +114,7 @@ export type ResponseCodes = {
 }
 
 type KinstaError = {
-  data: {
+  data?: {
     message: string
     status: keyof ResponseCodes
   }
@@ -172,11 +172,15 @@ async function request<TResponse>(token: string, url: string, options: RequestIn
       ux.error(kinstaError.error)
     }
 
-    if (data && data.status === 500) {
+    if (data?.status === 500 && kinstaError.data?.message) {
       ux.error(kinstaError.data.message)
     }
 
-    ux.error(kinstaError.message)
+    if (kinstaError.message) {
+      ux.error(kinstaError.message)
+    }
+
+    ux.error(`Kinsta API error (${statusCode}): ${JSON.stringify(data)}`)
   }
 
   // The response is still in progress, wait until it is finished.


### PR DESCRIPTION
## Summary

Fix TypeError crash in `request()` when Kinsta API returns error responses where `data` is undefined.

## Changes

- Make `KinstaError.data` optional in the type definition
- Add optional chaining (`kinstaError.data?.message`) to prevent TypeError
- Guard `kinstaError.message` with conditional check
- Add fallback that outputs raw JSON response for unexpected error shapes

## Testing

1. Trigger a Kinsta API error (e.g. invalid token or unavailable endpoint)
2. Verify the error message is displayed without crashing
3. Verify known error shapes still show their specific messages
