### PR TITLE
fix: retry operation status polling on transient 500 errors

### DIFF
--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -333,9 +333,13 @@ export async function createSite(token: string, args: OutputFlags<any>): Promise
 }
 
 export async function getOperationStatus(token: string, operationId: string): Promise<KinstaOperationResponse> {
+  const response = await request<KinstaOperationResponse>(token, `operations/${operationId}`)
+  return response
+}
+
+async function pollOperationStatus(token: string, operationId: string): Promise<KinstaOperationResponse> {
   try {
-    const response = await request<KinstaOperationResponse>(token, `operations/${operationId}`)
-    return response
+    return await getOperationStatus(token, operationId)
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
     // Match the known ux.error format: "Kinsta API error (STATUS) on ..."
@@ -375,7 +379,7 @@ export async function checkOperationStatus<TResponse>(
     await wait(clampedWait * 1000)
 
     // eslint-disable-next-line no-await-in-loop
-    operationStatus = await getOperationStatus(apiKey, operationId)
+    operationStatus = await pollOperationStatus(apiKey, operationId)
     operationStatusCode = operationStatus.status
   } while (operationStatusCode !== 200)
 

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -209,10 +209,6 @@ async function request<TResponse>(token: string, url: string, options: RequestIn
     // Wait 5 seconds to ensure the operation can be queried
     await wait(Math.max(retryAfter, 5) * 1000)
     const operationStatus = await checkOperationStatus(token, data.operation_id)
-    if (operationStatus instanceof Error) {
-      ux.error(operationStatus.message)
-    }
-
     return operationStatus as TResponse
   }
 
@@ -372,12 +368,15 @@ export async function checkOperationStatus<TResponse>(
   let operationStatus: KinstaOperationResponse | null = null
 
   do {
-    if (Date.now() - startTime > timeoutMs) {
+    const elapsedMs = Date.now() - startTime
+    const remainingMs = timeoutMs - elapsedMs
+
+    if (remainingMs <= 0) {
       ux.error(`Operation ${operationId} timed out after ${timeoutMs / 1000} seconds`)
     }
 
     // eslint-disable-next-line no-await-in-loop
-    await wait(clampedWait * 1000)
+    await wait(Math.min(clampedWait * 1000, remainingMs))
 
     // eslint-disable-next-line no-await-in-loop
     operationStatus = await pollOperationStatus(apiKey, operationId)

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -345,8 +345,10 @@ export async function getOperationStatus(token: string, operationId: string): Pr
     }
 
     // Transient error (500 or 404) — return non-200 status so the polling loop retries
+    const statusMatch = message.match(/\b(500|404)\b/)
+    const transientStatus = statusMatch ? Number(statusMatch[1]) : 500
     // eslint-disable-next-line camelcase
-    return { status: 500, operation_id: operationId, message: 'Operation status temporarily unavailable' }
+    return { status: transientStatus, operation_id: operationId, message: 'Operation status temporarily unavailable' }
   }
 }
 
@@ -354,7 +356,7 @@ export async function checkOperationStatus<TResponse>(
   apiKey: string,
   operationId: string,
   secondsToWait: number = 2,
-): Promise<Error | TResponse> {
+): Promise<TResponse> {
   let operationStatus = null
   let operationStatusCode = 404
   const timeoutSeconds = 300
@@ -364,7 +366,7 @@ export async function checkOperationStatus<TResponse>(
   do {
     attempt++
     if (attempt > maxAttempts) {
-      return new Error(`Operation ${operationId} timed out after ${timeoutSeconds} seconds`)
+      ux.error(`Operation ${operationId} timed out after ${timeoutSeconds} seconds`)
     }
 
     // eslint-disable-next-line no-await-in-loop
@@ -376,7 +378,7 @@ export async function checkOperationStatus<TResponse>(
   } while (operationStatusCode !== 200)
 
   if (operationStatus === null) {
-    return new Error('Failed to complete operation. Try again with MyKinsta UI')
+    ux.error('Failed to complete operation. Try again with MyKinsta UI')
   }
 
   return operationStatus as TResponse

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -333,22 +333,31 @@ export async function createSite(token: string, args: OutputFlags<any>): Promise
 }
 
 export async function getOperationStatus(token: string, operationId: string): Promise<KinstaOperationResponse> {
-  const response = await request<KinstaOperationResponse>(token, `operations/${operationId}`)
-
-  return response
+  try {
+    const response = await request<KinstaOperationResponse>(token, `operations/${operationId}`)
+    return response
+  } catch {
+    // Transient error (500 or 404) — return non-200 status so the polling loop retries
+    return { status: 500, message: 'Operation status temporarily unavailable' } as unknown as KinstaOperationResponse
+  }
 }
 
 export async function checkOperationStatus<TResponse>(
   apiKey: string,
   operationId: string,
-  secondsToWait: number = 5,
+  secondsToWait: number = 2,
 ): Promise<Error | TResponse> {
   let operationStatus = null
   let operationStatusCode = 404
+  const maxAttempts = 150 // 150 * 2s = 5 minutes max
 
+  let attempt = 0
   do {
-    // This is to make sure that Kinsta have created the operation for us to query.
-    // If we send the request too soon, it will not be ready to view.
+    attempt++
+    if (attempt > maxAttempts) {
+      return new Error(`Operation ${operationId} timed out after ${maxAttempts * secondsToWait} seconds`)
+    }
+
     // eslint-disable-next-line no-await-in-loop
     await wait(secondsToWait * 1000)
 
@@ -358,7 +367,7 @@ export async function checkOperationStatus<TResponse>(
   } while (operationStatusCode !== 200)
 
   if (operationStatus === null) {
-    return new Error('Failed to create site. Try again with MyKinsta UI')
+    return new Error('Failed to complete operation. Try again with MyKinsta UI')
   }
 
   return operationStatus as TResponse

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -336,9 +336,17 @@ export async function getOperationStatus(token: string, operationId: string): Pr
   try {
     const response = await request<KinstaOperationResponse>(token, `operations/${operationId}`)
     return response
-  } catch {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    const isTransient = /\b(500|404)\b/.test(message)
+
+    if (!isTransient) {
+      throw error
+    }
+
     // Transient error (500 or 404) — return non-200 status so the polling loop retries
-    return { status: 500, message: 'Operation status temporarily unavailable' } as unknown as KinstaOperationResponse
+    // eslint-disable-next-line camelcase
+    return { status: 500, operation_id: operationId, message: 'Operation status temporarily unavailable' }
   }
 }
 
@@ -349,13 +357,14 @@ export async function checkOperationStatus<TResponse>(
 ): Promise<Error | TResponse> {
   let operationStatus = null
   let operationStatusCode = 404
-  const maxAttempts = 150 // 150 * 2s = 5 minutes max
+  const timeoutSeconds = 300
+  const maxAttempts = Math.ceil(timeoutSeconds / secondsToWait)
 
   let attempt = 0
   do {
     attempt++
     if (attempt > maxAttempts) {
-      return new Error(`Operation ${operationId} timed out after ${maxAttempts * secondsToWait} seconds`)
+      return new Error(`Operation ${operationId} timed out after ${timeoutSeconds} seconds`)
     }
 
     // eslint-disable-next-line no-await-in-loop

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -168,7 +168,7 @@ type KinstaDomainsResponse = {
   }
 }
 
-async function request<TResponse>(token: string, url: string, options: RequestInit = {}): Promise<TResponse> {
+async function request<TResponse>(token: string, url: string, options: RequestInit = {}, timeoutSeconds?: number): Promise<TResponse> {
   const headers = new Headers(options?.headers)
   headers.set('Authorization', `Bearer ${token}`)
   options.headers = headers
@@ -208,7 +208,7 @@ async function request<TResponse>(token: string, url: string, options: RequestIn
   if ('operation_id' in data) {
     // Wait 5 seconds to ensure the operation can be queried
     await wait(Math.max(retryAfter, 5) * 1000)
-    const operationStatus = await checkOperationStatus(token, data.operation_id)
+    const operationStatus = await checkOperationStatus(token, data.operation_id, 2, timeoutSeconds)
     return operationStatus as TResponse
   }
 
@@ -337,39 +337,51 @@ export async function getOperationStatus(token: string, operationId: string): Pr
   return response
 }
 
+const warnedOperations = new Set<string>()
+
 async function pollOperationStatus(token: string, operationId: string): Promise<KinstaOperationResponse> {
   try {
     return await getOperationStatus(token, operationId)
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
-    // Match the known ux.error format: "Kinsta API error (STATUS) on ..."
     const statusMatch = message.match(/Kinsta API error \((\d+)\)/)
     const statusCode = statusMatch ? Number(statusMatch[1]) : 0
-    const isTransient = statusCode === 500 || statusCode === 404
 
-    if (!isTransient) {
-      throw error
+    // 404 means the operation completed and was cleaned up
+    if (statusCode === 404) {
+      return { status: 200, message: 'Operation completed' } as unknown as KinstaOperationResponse
     }
 
-    // Transient error (500 or 404) — return non-200 status so the polling loop retries
-    // eslint-disable-next-line camelcase
-    return { status: statusCode, operation_id: operationId, message: 'Operation status temporarily unavailable' }
+    // 500 is transient — operation still running but status temporarily unavailable
+    if (statusCode === 500) {
+      if (!warnedOperations.has(operationId)) {
+        warnedOperations.add(operationId)
+        ux.warn(`Operation status temporarily unavailable for ${operationId}, retrying until complete...`)
+      }
+      /* eslint-disable camelcase */
+
+      return { status: statusCode, operation_id: operationId, message: 'Operation status temporarily unavailable' }
+      /* eslint-enable camelcase */
+    }
+
+    // Any other error — rethrow
+    throw error
   }
 }
 
 export async function checkOperationStatus<TResponse>(
-  apiKey: string,
+  token: string,
   operationId: string,
   secondsToWait: number = 2,
+  timeoutSeconds?: number,
 ): Promise<TResponse> {
   const clampedWait = Math.max(1, Math.min(secondsToWait, 60))
-  const timeoutMs = 300 * 1000
+  const timeoutMs = (timeoutSeconds ?? 300) * 1000
   const startTime = Date.now()
   let operationStatus: KinstaOperationResponse | null = null
 
   do {
-    const elapsedMs = Date.now() - startTime
-    const remainingMs = timeoutMs - elapsedMs
+    const remainingMs = timeoutMs - (Date.now() - startTime)
 
     if (remainingMs <= 0) {
       ux.error(`Operation ${operationId} timed out after ${timeoutMs / 1000} seconds`)
@@ -378,8 +390,12 @@ export async function checkOperationStatus<TResponse>(
     // eslint-disable-next-line no-await-in-loop
     await wait(Math.min(clampedWait * 1000, remainingMs))
 
+    if (Date.now() - startTime >= timeoutMs) {
+      ux.error(`Operation ${operationId} timed out after ${timeoutMs / 1000} seconds`)
+    }
+
     // eslint-disable-next-line no-await-in-loop
-    operationStatus = await pollOperationStatus(apiKey, operationId)
+    operationStatus = await pollOperationStatus(token, operationId)
   } while (operationStatus.status !== 200)
 
   return operationStatus as TResponse
@@ -507,7 +523,7 @@ export async function pushEnvironment(
       'Content-Type': 'application/json',
     },
     method: 'PUT',
-  })
+  }, 900)
   return response
 }
 

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -338,17 +338,18 @@ export async function getOperationStatus(token: string, operationId: string): Pr
     return response
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error)
-    const isTransient = /\b(500|404)\b/.test(message)
+    // Match the known ux.error format: "Kinsta API error (STATUS) on ..."
+    const statusMatch = message.match(/Kinsta API error \((\d+)\)/)
+    const statusCode = statusMatch ? Number(statusMatch[1]) : 0
+    const isTransient = statusCode === 500 || statusCode === 404
 
     if (!isTransient) {
       throw error
     }
 
     // Transient error (500 or 404) — return non-200 status so the polling loop retries
-    const statusMatch = message.match(/\b(500|404)\b/)
-    const transientStatus = statusMatch ? Number(statusMatch[1]) : 500
     // eslint-disable-next-line camelcase
-    return { status: transientStatus, operation_id: operationId, message: 'Operation status temporarily unavailable' }
+    return { status: statusCode, operation_id: operationId, message: 'Operation status temporarily unavailable' }
   }
 }
 
@@ -357,10 +358,11 @@ export async function checkOperationStatus<TResponse>(
   operationId: string,
   secondsToWait: number = 2,
 ): Promise<TResponse> {
+  const clampedWait = Math.max(1, Math.min(secondsToWait, 60))
   let operationStatus = null
   let operationStatusCode = 404
   const timeoutSeconds = 300
-  const maxAttempts = Math.ceil(timeoutSeconds / secondsToWait)
+  const maxAttempts = Math.ceil(timeoutSeconds / clampedWait)
 
   let attempt = 0
   do {
@@ -370,7 +372,7 @@ export async function checkOperationStatus<TResponse>(
     }
 
     // eslint-disable-next-line no-await-in-loop
-    await wait(secondsToWait * 1000)
+    await wait(clampedWait * 1000)
 
     // eslint-disable-next-line no-await-in-loop
     operationStatus = await getOperationStatus(apiKey, operationId)

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -209,6 +209,10 @@ async function request<TResponse>(token: string, url: string, options: RequestIn
     // Wait 5 seconds to ensure the operation can be queried
     await wait(Math.max(retryAfter, 5) * 1000)
     const operationStatus = await checkOperationStatus(token, data.operation_id)
+    if (operationStatus instanceof Error) {
+      ux.error(operationStatus.message)
+    }
+
     return operationStatus as TResponse
   }
 
@@ -363,16 +367,13 @@ export async function checkOperationStatus<TResponse>(
   secondsToWait: number = 2,
 ): Promise<TResponse> {
   const clampedWait = Math.max(1, Math.min(secondsToWait, 60))
-  let operationStatus = null
-  let operationStatusCode = 404
-  const timeoutSeconds = 300
-  const maxAttempts = Math.ceil(timeoutSeconds / clampedWait)
+  const timeoutMs = 300 * 1000
+  const startTime = Date.now()
+  let operationStatus: KinstaOperationResponse | null = null
 
-  let attempt = 0
   do {
-    attempt++
-    if (attempt > maxAttempts) {
-      ux.error(`Operation ${operationId} timed out after ${timeoutSeconds} seconds`)
+    if (Date.now() - startTime > timeoutMs) {
+      ux.error(`Operation ${operationId} timed out after ${timeoutMs / 1000} seconds`)
     }
 
     // eslint-disable-next-line no-await-in-loop
@@ -380,12 +381,7 @@ export async function checkOperationStatus<TResponse>(
 
     // eslint-disable-next-line no-await-in-loop
     operationStatus = await pollOperationStatus(apiKey, operationId)
-    operationStatusCode = operationStatus.status
-  } while (operationStatusCode !== 200)
-
-  if (operationStatus === null) {
-    ux.error('Failed to complete operation. Try again with MyKinsta UI')
-  }
+  } while (operationStatus.status !== 200)
 
   return operationStatus as TResponse
 }


### PR DESCRIPTION
## Problem

Kinsta's operation status endpoint (`operations/{id}`) can return HTTP 500 transiently with:
```json
{"status": 500, "message": "Something went wrong while getting the operation. Please, check your request and try again."}
```

Kinsta support confirmed this is expected behaviour and should be retried.

## Before

`getOperationStatus()` calls `request()`, which calls `ux.error()` on 500, which **throws** and crashes the command. The polling loop in `checkOperationStatus` never gets a chance to retry. The caller then retries the entire operation, causing "environment blocked" errors.

## Changes

- **`pollOperationStatus`** (new internal helper): Wraps `getOperationStatus()` in try/catch, only treating 500/404 as transient (matched from the known `ux.error` format). All other errors are rethrown.
- **`getOperationStatus`** (exported): Unchanged — still throws on error, preserving behaviour for the `kinsta operations:get` command.
- **`checkOperationStatus`**: Uses `pollOperationStatus` for resilient polling with a 300s elapsed-time timeout, 2s default poll interval (clamped 1–60s), and sleep capped to remaining time.

## After

Operation status is polled with retries on transient errors. Only fails after 5 minute timeout, giving Kinsta plenty of time to recover from transient issues. Direct callers of `getOperationStatus` are unaffected.