### PR TITLE
feat(kinsta): add kinsta env logs get command

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,9 @@
       "kinsta:backups": {
         "description": "Manage Kinsta WordPress site environment backups"
       },
+      "kinsta:logs": {
+        "description": "Fetch Kinsta site environment logs"
+      },
       "kinsta:sites": {
         "description": "Manage Kinsta WordPress sites"
       },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "kinsta:backups": {
         "description": "Manage Kinsta WordPress site environment backups"
       },
-      "kinsta:logs": {
+      "kinsta:env:logs": {
         "description": "Fetch Kinsta site environment logs"
       },
       "kinsta:sites": {

--- a/src/commands/kinsta/env/logs/get.ts
+++ b/src/commands/kinsta/env/logs/get.ts
@@ -1,7 +1,7 @@
 import {Flags} from '@oclif/core'
 
 import {KinstaCommand} from '../../../../lib/commands/kinsta-command.js'
-import {getLogs, KinstaLogFileName} from '../../../../lib/kinsta.js'
+import {getLogs, KINSTA_LOG_FILE_NAMES, KinstaLogFileName} from '../../../../lib/kinsta.js'
 
 export default class Get extends KinstaCommand {
   static description = 'Fetch logs for a Kinsta environment'
@@ -15,7 +15,7 @@ export default class Get extends KinstaCommand {
     // eslint-disable-next-line camelcase
     file_name: Flags.string({
       default: 'error',
-      options: ['access', 'error', 'kinsta-cache-perf'],
+      options: [...KINSTA_LOG_FILE_NAMES],
       required: true,
     }),
     format: Flags.string({

--- a/src/commands/kinsta/env/logs/get.ts
+++ b/src/commands/kinsta/env/logs/get.ts
@@ -1,7 +1,7 @@
 import {Flags} from '@oclif/core'
 
-import {KinstaCommand} from '../../../lib/commands/kinsta-command.js'
-import {getLogs, KinstaLogFileName} from '../../../lib/kinsta.js'
+import {KinstaCommand} from '../../../../lib/commands/kinsta-command.js'
+import {getLogs, KinstaLogFileName} from '../../../../lib/kinsta.js'
 
 export default class Get extends KinstaCommand {
   static description = 'Fetch logs for a Kinsta environment'

--- a/src/commands/kinsta/logs/get.ts
+++ b/src/commands/kinsta/logs/get.ts
@@ -1,0 +1,47 @@
+import {Flags} from '@oclif/core'
+
+import {KinstaCommand} from '../../../lib/commands/kinsta-command.js'
+import {getLogs, KinstaLogFileName} from '../../../lib/kinsta.js'
+
+export default class Get extends KinstaCommand {
+  static description = 'Fetch logs for a Kinsta environment'
+  static examples = ['<%= config.bin %> <%= command.id %>']
+  static flags = {
+    // eslint-disable-next-line camelcase
+    environment_id: Flags.string({
+      env: 'IROOTS_KINSTA_ENVIRONMENT_ID',
+      required: true,
+    }),
+    // eslint-disable-next-line camelcase
+    file_name: Flags.string({
+      default: 'error',
+      options: ['access', 'error', 'kinsta-cache-perf'],
+      required: true,
+    }),
+    format: Flags.string({
+      default: 'text',
+      options: ['json', 'text'],
+      required: false,
+    }),
+    lines: Flags.integer({
+      default: 1000,
+      max: 20_000,
+      required: true,
+    }),
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Get)
+    // eslint-disable-next-line camelcase
+    const {apiKey, environment_id, file_name, format, lines} = flags
+
+    // eslint-disable-next-line camelcase
+    const logs = await getLogs(apiKey, environment_id, file_name as KinstaLogFileName, lines)
+
+    if (format === 'json') {
+      console.log(JSON.stringify({logs}))
+    } else {
+      console.log(logs)
+    }
+  }
+}

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -634,3 +634,28 @@ export async function getCompanyUsers(token: string, companyId: string): Promise
   const response = await request<KinstaCompanyUsersResponse>(token, `company/${companyId}/users`)
   return response.company.users.map(({user}) => user)
 }
+
+export type KinstaLogFileName = 'access' | 'error' | 'kinsta-cache-perf'
+
+type KinstaLogsResponse = {
+  environment: {
+    container_info: {
+      logs: string
+    }
+  }
+}
+
+export async function getLogs(
+  token: string,
+  envId: string,
+  // eslint-disable-next-line camelcase
+  file_name: KinstaLogFileName,
+  lines: number,
+): Promise<string> {
+  const response = await request<KinstaLogsResponse>(
+    token,
+    // eslint-disable-next-line camelcase
+    `sites/environments/${envId}/logs?file_name=${file_name}&lines=${lines}`,
+  )
+  return response.environment.container_info.logs
+}

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -635,7 +635,8 @@ export async function getCompanyUsers(token: string, companyId: string): Promise
   return response.company.users.map(({user}) => user)
 }
 
-export type KinstaLogFileName = 'access' | 'error' | 'kinsta-cache-perf'
+export const KINSTA_LOG_FILE_NAMES = ['access', 'error', 'kinsta-cache-perf'] as const
+export type KinstaLogFileName = (typeof KINSTA_LOG_FILE_NAMES)[number]
 
 type KinstaLogsResponse = {
   environment: {

--- a/src/lib/kinsta.ts
+++ b/src/lib/kinsta.ts
@@ -648,14 +648,15 @@ type KinstaLogsResponse = {
 export async function getLogs(
   token: string,
   envId: string,
-  // eslint-disable-next-line camelcase
-  file_name: KinstaLogFileName,
+  fileName: KinstaLogFileName,
   lines: number,
 ): Promise<string> {
+  const params = new URLSearchParams()
+  params.append('file_name', fileName)
+  params.append('lines', String(lines))
   const response = await request<KinstaLogsResponse>(
     token,
-    // eslint-disable-next-line camelcase
-    `sites/environments/${envId}/logs?file_name=${file_name}&lines=${lines}`,
+    `sites/environments/${envId}/logs?${params.toString()}`,
   )
   return response.environment.container_info.logs
 }


### PR DESCRIPTION
## Summary

Adds a new `iroots kinsta env logs get` command to fetch log files from a Kinsta site environment via the Kinsta API v2 logs endpoint.

## Changes

- **`src/lib/kinsta.ts`** — adds `KinstaLogFileName` type and `getLogs()` function calling `GET /sites/environments/{env_id}/logs`
- **`src/commands/kinsta/env/logs/get.ts`** — new oclif command extending `KinstaCommand` with flags:
  - `--environment_id` (required, env: `IROOTS_KINSTA_ENVIRONMENT_ID`)
  - `--file_name` — `error` | `access` | `kinsta-cache-perf` (default: `error`)
  - `--lines` — number of lines to fetch, max 20,000 (default: `1000`)
  - `--format` — `text` | `json` (default: `text`)
- **`package.json`** — registers `kinsta:env:logs` topic in the oclif config

## Testing

```bash
# Fetch last 100 error log lines for an environment
iroots kinsta env logs get --environment_id <env_id> --file_name error --lines 100

# Fetch access logs as JSON
iroots kinsta env logs get --environment_id <env_id> --file_name access --format json

# Fetch cache performance logs
iroots kinsta env logs get --environment_id <env_id> --file_name kinsta-cache-perf
```
