### PR TITLE
feat(kinsta): add environment browser opener command

### DIFF
--- a/src/commands/kinsta/env/open.ts
+++ b/src/commands/kinsta/env/open.ts
@@ -123,11 +123,21 @@ async function resolveSite(sites: KinstaSite[], candidates: string[], explicitSi
     return promptForSite(explicitMatches, `Multiple sites matched --site "${explicitSite}". Select one:`)
   }
 
+  const inferredMatches = new Map<string, KinstaSite>()
   for (const candidate of candidates) {
     const matches = findMatchingSites(sites, candidate)
-    if (matches.length === 1) {
-      return matches[0]
+    for (const match of matches) {
+      inferredMatches.set(match.id, match)
     }
+  }
+
+  const uniqueInferredMatches = [...inferredMatches.values()]
+  if (uniqueInferredMatches.length === 1) {
+    return uniqueInferredMatches[0]
+  }
+
+  if (uniqueInferredMatches.length > 1) {
+    return promptForSite(uniqueInferredMatches, 'Multiple inferred sites matched. Select a Kinsta site:')
   }
 
   return promptForSite(sites, 'Select a Kinsta site:')

--- a/src/commands/kinsta/env/open.ts
+++ b/src/commands/kinsta/env/open.ts
@@ -74,7 +74,13 @@ export default class Open extends KinstaCommand {
       site,
       ...(inference?.siteNames ?? []),
     ])
-    const selectedSite = await resolveSite(sites, siteCandidates, site)
+    let selectedSite: KinstaSite
+    try {
+      selectedSite = await resolveSite(sites, siteCandidates, site)
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.error(message)
+    }
 
     const environments = selectedSite.environments ?? []
     if (environments.length === 0) {
@@ -88,13 +94,19 @@ export default class Open extends KinstaCommand {
     }
 
     const environmentCandidates = compact([environment])
-    const selectedEnvironment = await resolveEnvironment(environments, environmentCandidates, environment)
+    let selectedEnvironment: KinstaEnvironment
+    try {
+      selectedEnvironment = await resolveEnvironment(environments, environmentCandidates, environment)
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.error(message)
+    }
 
     await this.openEnvironment(selectedSite.id, selectedEnvironment.id)
   }
 
   private async openEnvironment(siteId: string, environmentId: string): Promise<void> {
-    const url = `https://my.kinsta.com/sites/details/${encodeURIComponent(siteId)}/${encodeURIComponent(environmentId)}?`
+    const url = `https://my.kinsta.com/sites/details/${encodeURIComponent(siteId)}/${encodeURIComponent(environmentId)}`
     this.log(`URL: ${url}`)
 
     ux.action.start('Opening environment in browser')

--- a/src/commands/kinsta/env/open.ts
+++ b/src/commands/kinsta/env/open.ts
@@ -41,8 +41,8 @@ export default class Open extends KinstaCommand {
   public async run(): Promise<void> {
     const {flags} = await this.parse(Open)
     const {apiKey, company, site, environment} = flags
-    const siteIdFlag = flags.site_id?.trim()
-    const environmentIdFlag = flags.environment_id?.trim()
+    const siteIdFlag = normalizeOptionalFlag(flags.site_id)
+    const environmentIdFlag = normalizeOptionalFlag(flags.environment_id)
 
     if ((siteIdFlag === undefined) !== (environmentIdFlag === undefined)) {
       this.error('Provide both --site_id and --environment_id together, or provide neither.')
@@ -190,6 +190,11 @@ function normalize(value: string): string {
 
 function compact(values: Array<string | undefined>): string[] {
   return values.filter((value): value is string => value !== undefined && value.trim().length > 0)
+}
+
+function normalizeOptionalFlag(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+  return normalized !== undefined && normalized.length > 0 ? normalized : undefined
 }
 
 async function promptForSite(sites: KinstaSite[], message: string): Promise<KinstaSite> {

--- a/src/commands/kinsta/env/open.ts
+++ b/src/commands/kinsta/env/open.ts
@@ -40,7 +40,10 @@ export default class Open extends KinstaCommand {
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(Open)
-    const {apiKey, company, site, environment} = flags
+    const {apiKey} = flags
+    const company = normalizeOptionalFlag(flags.company)
+    const site = normalizeOptionalFlag(flags.site)
+    const environment = normalizeOptionalFlag(flags.environment)
     const siteIdFlag = normalizeOptionalFlag(flags.site_id)
     const environmentIdFlag = normalizeOptionalFlag(flags.environment_id)
 
@@ -57,7 +60,7 @@ export default class Open extends KinstaCommand {
       this.error('Could not resolve IDs directly. Provide --company or set IROOTS_KINSTA_COMPANY_ID.')
     }
 
-    const inference = await inferKinstaFromTrellis(process.cwd())
+    const inference = site === undefined ? await inferKinstaFromTrellis(process.cwd()) : null
 
     ux.action.start('Fetching Kinsta sites')
     const sites = await getAllSites(apiKey, company, true)

--- a/src/commands/kinsta/env/open.ts
+++ b/src/commands/kinsta/env/open.ts
@@ -53,11 +53,11 @@ export default class Open extends KinstaCommand {
       return
     }
 
-    const inference = await inferKinstaFromTrellis(process.cwd())
-
     if (company === undefined) {
       this.error('Could not resolve IDs directly. Provide --company or set IROOTS_KINSTA_COMPANY_ID.')
     }
+
+    const inference = await inferKinstaFromTrellis(process.cwd())
 
     ux.action.start('Fetching Kinsta sites')
     const sites = await getAllSites(apiKey, company, true)
@@ -73,9 +73,12 @@ export default class Open extends KinstaCommand {
     ])
     const selectedSite = await resolveSite(sites, siteCandidates, site)
 
-    ux.action.start(`Fetching environments for site "${selectedSite.display_name}"`)
-    const environments = await getSiteEnvironments(apiKey, selectedSite.id)
-    ux.action.stop()
+    const environments = selectedSite.environments ?? []
+    if (environments.length === 0) {
+      ux.action.start(`Fetching environments for site "${selectedSite.display_name}"`)
+      environments.push(...await getSiteEnvironments(apiKey, selectedSite.id))
+      ux.action.stop()
+    }
 
     if (environments.length === 0) {
       this.error(`No environments found for site "${selectedSite.display_name}"`)
@@ -182,7 +185,7 @@ function findMatchingEnvironments(environments: KinstaEnvironment[], candidate: 
 }
 
 function normalize(value: string): string {
-  return value.trim().toLocaleLowerCase()
+  return value.trim().toLowerCase()
 }
 
 function compact(values: Array<string | undefined>): string[] {

--- a/src/commands/kinsta/env/open.ts
+++ b/src/commands/kinsta/env/open.ts
@@ -1,0 +1,230 @@
+import {select} from '@inquirer/prompts'
+import {Flags, ux} from '@oclif/core'
+
+import {openUrlInBrowser} from '../../../lib/browser.js'
+import {KinstaCommand} from '../../../lib/commands/kinsta-command.js'
+import {getAllSites, getSiteEnvironments, KinstaSite} from '../../../lib/kinsta.js'
+import {inferKinstaFromTrellis} from '../../../lib/trellis-kinsta.js'
+
+type KinstaEnvironment = Awaited<ReturnType<typeof getSiteEnvironments>>[number]
+
+export default class Open extends KinstaCommand {
+  static description = 'Open a Kinsta environment in your default web browser'
+  static examples = ['<%= config.bin %> <%= command.id %>']
+  static flags = {
+    company: Flags.string({
+      description: 'Kinsta company ID (required when site/environment IDs are not resolved directly)',
+      env: 'IROOTS_KINSTA_COMPANY_ID',
+      required: false,
+    }),
+    environment: Flags.string({
+      description: 'Environment name (case-insensitive exact match)',
+      required: false,
+    }),
+    // eslint-disable-next-line camelcase
+    environment_id: Flags.string({
+      description: 'Environment ID (takes priority over inferred values)',
+      env: 'IROOTS_KINSTA_ENVIRONMENT_ID',
+      required: false,
+    }),
+    site: Flags.string({
+      description: 'Site name (case-insensitive exact match)',
+      required: false,
+    }),
+    // eslint-disable-next-line camelcase
+    site_id: Flags.string({
+      description: 'Site ID (takes priority over inferred values)',
+      required: false,
+    }),
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Open)
+    const {apiKey, company, site, environment} = flags
+    const siteIdFlag = flags.site_id?.trim()
+    const environmentIdFlag = flags.environment_id?.trim()
+
+    if ((siteIdFlag === undefined) !== (environmentIdFlag === undefined)) {
+      this.error('Provide both --site_id and --environment_id together, or provide neither.')
+    }
+
+    if (siteIdFlag !== undefined && environmentIdFlag !== undefined) {
+      await this.openEnvironment(siteIdFlag, environmentIdFlag)
+      return
+    }
+
+    const inference = await inferKinstaFromTrellis(process.cwd())
+
+    if (company === undefined) {
+      this.error('Could not resolve IDs directly. Provide --company or set IROOTS_KINSTA_COMPANY_ID.')
+    }
+
+    ux.action.start('Fetching Kinsta sites')
+    const sites = await getAllSites(apiKey, company, true)
+    ux.action.stop()
+
+    if (sites.length === 0) {
+      this.error(`No Kinsta sites found for company "${company}"`)
+    }
+
+    const siteCandidates = compact([
+      site,
+      ...(inference?.siteNames ?? []),
+    ])
+    const selectedSite = await resolveSite(sites, siteCandidates, site)
+
+    ux.action.start(`Fetching environments for site "${selectedSite.display_name}"`)
+    const environments = await getSiteEnvironments(apiKey, selectedSite.id)
+    ux.action.stop()
+
+    if (environments.length === 0) {
+      this.error(`No environments found for site "${selectedSite.display_name}"`)
+    }
+
+    const environmentCandidates = compact([environment])
+    const selectedEnvironment = await resolveEnvironment(environments, environmentCandidates, environment)
+
+    await this.openEnvironment(selectedSite.id, selectedEnvironment.id)
+  }
+
+  private async openEnvironment(siteId: string, environmentId: string): Promise<void> {
+    const url = `https://my.kinsta.com/sites/details/${encodeURIComponent(siteId)}/${encodeURIComponent(environmentId)}?`
+    this.log(`URL: ${url}`)
+
+    ux.action.start('Opening environment in browser')
+    try {
+      await openUrlInBrowser(url)
+      ux.action.stop()
+    } catch (error: unknown) {
+      ux.action.stop('failed')
+      const message = error instanceof Error ? error.message : String(error)
+      this.error(message)
+    }
+  }
+}
+
+async function resolveSite(sites: KinstaSite[], candidates: string[], explicitSite: string | undefined): Promise<KinstaSite> {
+  if (explicitSite !== undefined) {
+    const explicitMatches = findMatchingSites(sites, explicitSite)
+    if (explicitMatches.length === 0) {
+      throw new Error(`No Kinsta site matched --site "${explicitSite}"`)
+    }
+
+    if (explicitMatches.length === 1) {
+      return explicitMatches[0]
+    }
+
+    return promptForSite(explicitMatches, `Multiple sites matched --site "${explicitSite}". Select one:`)
+  }
+
+  for (const candidate of candidates) {
+    const matches = findMatchingSites(sites, candidate)
+    if (matches.length === 1) {
+      return matches[0]
+    }
+  }
+
+  return promptForSite(sites, 'Select a Kinsta site:')
+}
+
+async function resolveEnvironment(
+  environments: KinstaEnvironment[],
+  candidates: string[],
+  explicitEnvironment: string | undefined,
+): Promise<KinstaEnvironment> {
+  if (explicitEnvironment !== undefined) {
+    const explicitMatches = findMatchingEnvironments(environments, explicitEnvironment)
+    if (explicitMatches.length === 0) {
+      throw new Error(`No environment matched --environment "${explicitEnvironment}"`)
+    }
+
+    if (explicitMatches.length === 1) {
+      return explicitMatches[0]
+    }
+
+    return promptForEnvironment(explicitMatches, `Multiple environments matched --environment "${explicitEnvironment}". Select one:`)
+  }
+
+  for (const candidate of candidates) {
+    const matches = findMatchingEnvironments(environments, candidate)
+    if (matches.length === 1) {
+      return matches[0]
+    }
+  }
+
+  return promptForEnvironment(environments, 'Select an environment:')
+}
+
+function findMatchingSites(sites: KinstaSite[], candidate: string): KinstaSite[] {
+  const normalizedCandidate = normalize(candidate)
+
+  return sites.filter(site => (
+    normalize(site.id) === normalizedCandidate
+    || normalize(site.name) === normalizedCandidate
+    || normalize(site.display_name) === normalizedCandidate
+  ))
+}
+
+function findMatchingEnvironments(environments: KinstaEnvironment[], candidate: string): KinstaEnvironment[] {
+  const normalizedCandidate = normalize(candidate)
+
+  const idMatches = environments.filter(environment => normalize(environment.id) === normalizedCandidate)
+  if (idMatches.length > 0) {
+    return idMatches
+  }
+
+  const displayNameMatches = environments.filter(environment => normalize(environment.display_name) === normalizedCandidate)
+  if (displayNameMatches.length > 0) {
+    return displayNameMatches
+  }
+
+  return environments.filter(environment => normalize(environment.name) === normalizedCandidate)
+}
+
+function normalize(value: string): string {
+  return value.trim().toLocaleLowerCase()
+}
+
+function compact(values: Array<string | undefined>): string[] {
+  return values.filter((value): value is string => value !== undefined && value.trim().length > 0)
+}
+
+async function promptForSite(sites: KinstaSite[], message: string): Promise<KinstaSite> {
+  const sortedSites = [...sites].sort((a, b) => a.display_name.localeCompare(b.display_name))
+
+  const siteId = await select({
+    message,
+    choices: sortedSites.map(site => ({
+      name: formatSiteChoice(site),
+      value: site.id,
+    })),
+  })
+
+  return sortedSites.find(site => site.id === siteId) ?? sortedSites[0]
+}
+
+function formatSiteChoice(site: KinstaSite): string {
+  const environments = site.environments
+    ?.map(environment => environment.display_name || environment.name)
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b)) ?? []
+  const environmentSummary = environments.length > 0
+    ? ` envs: ${environments.join(', ')}`
+    : ' envs: unknown'
+
+  return `${site.display_name} (${site.name}) [${site.id}]${environmentSummary}`
+}
+
+async function promptForEnvironment(environments: KinstaEnvironment[], message: string): Promise<KinstaEnvironment> {
+  const sortedEnvironments = [...environments].sort((a, b) => a.display_name.localeCompare(b.display_name))
+
+  const environmentId = await select({
+    message,
+    choices: sortedEnvironments.map(environment => ({
+      name: `${environment.display_name} (${environment.name}) [${environment.id}]`,
+      value: environment.id,
+    })),
+  })
+
+  return sortedEnvironments.find(environment => environment.id === environmentId) ?? sortedEnvironments[0]
+}

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -33,8 +33,8 @@ function getOpenCommand(url: string): OpenCommand {
 
   if (process.platform === 'win32') {
     return {
-      binary: 'cmd',
-      args: ['/c', 'start', '', url],
+      binary: 'explorer.exe',
+      args: [url],
     }
   }
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,0 +1,42 @@
+import {execa} from 'execa'
+
+export async function openUrlInBrowser(url: string): Promise<void> {
+  const command = getOpenCommand(url)
+
+  try {
+    await execa(command.binary, command.args)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to open browser for URL: ${url}\n${message}`)
+  }
+}
+
+type OpenCommand = {
+  args: string[]
+  binary: string
+}
+
+function getOpenCommand(url: string): OpenCommand {
+  if (process.platform === 'darwin') {
+    return {
+      binary: 'open',
+      args: [url],
+    }
+  }
+
+  if (process.platform === 'linux') {
+    return {
+      binary: 'xdg-open',
+      args: [url],
+    }
+  }
+
+  if (process.platform === 'win32') {
+    return {
+      binary: 'cmd',
+      args: ['/c', 'start', '', url],
+    }
+  }
+
+  throw new Error(`Unsupported platform "${process.platform}". URL: ${url}`)
+}

--- a/src/lib/trellis-kinsta.ts
+++ b/src/lib/trellis-kinsta.ts
@@ -1,0 +1,89 @@
+import {globby} from 'globby'
+import {existsSync, readFileSync} from 'node:fs'
+import {basename, dirname, join, resolve} from 'node:path'
+
+export type TrellisKinstaInference = {
+  environmentNames: string[]
+  siteNames: string[]
+  trellisRoot: string
+}
+
+export async function inferKinstaFromTrellis(cwd: string = process.cwd()): Promise<null | TrellisKinstaInference> {
+  const trellisRoot = findTrellisRoot(cwd)
+  if (trellisRoot === null) {
+    return null
+  }
+
+  const files = await globby([
+    `${trellisRoot}/group_vars/*/*.yml`,
+    `${trellisRoot}/group_vars/*/*.yaml`,
+  ])
+
+  const siteNames = new Set<string>()
+  const environmentNames = new Set<string>()
+
+  for (const file of files) {
+    const content = readFileSync(file, 'utf8')
+    if (file.endsWith('/wordpress_sites.yml') || file.endsWith('/wordpress_sites.yaml')) {
+      collectRegexMatches(content, [/^\s+db_name:\s*["']?([^"'#\s]+)/gim], siteNames)
+      collectRegexMatches(content, [/^\s+db_user:\s*["']?([^"'#\s]+)/gim], siteNames)
+      collectRegexMatches(content, [/^\s+web_user:\s*["']?([^"'#\s]+)/gim], siteNames)
+    }
+  }
+
+  const groupVarDirs = await globby([`${trellisRoot}/group_vars/*`], {
+    onlyDirectories: true,
+  })
+
+  for (const dir of groupVarDirs) {
+    const envName = basename(dir)
+    if (envName !== 'all' && envName !== 'development') {
+      environmentNames.add(envName)
+    }
+  }
+
+  return {
+    environmentNames: [...environmentNames],
+    siteNames: [...siteNames],
+    trellisRoot,
+  }
+}
+
+function findTrellisRoot(cwd: string): null | string {
+  let current = resolve(cwd)
+
+  while (true) {
+    if (isTrellisRoot(current)) {
+      return current
+    }
+
+    const siblingTrellis = join(current, 'trellis')
+    if (isTrellisRoot(siblingTrellis)) {
+      return siblingTrellis
+    }
+
+    const parent = dirname(current)
+    if (parent === current) {
+      return null
+    }
+
+    current = parent
+  }
+}
+
+function isTrellisRoot(directory: string): boolean {
+  return existsSync(join(directory, 'group_vars')) && existsSync(join(directory, 'hosts'))
+}
+
+function collectRegexMatches(content: string, patterns: RegExp[], target: Set<string>): void {
+  for (const pattern of patterns) {
+    let match
+
+    while ((match = pattern.exec(content)) !== null) {
+      const value = match[1]?.trim()
+      if (value !== undefined && value.length > 0) {
+        target.add(value)
+      }
+    }
+  }
+}

--- a/src/lib/trellis-kinsta.ts
+++ b/src/lib/trellis-kinsta.ts
@@ -23,12 +23,15 @@ export async function inferKinstaFromTrellis(cwd: string = process.cwd()): Promi
   const environmentNames = new Set<string>()
 
   for (const file of files) {
-    const content = readFileSync(file, 'utf8')
-    if (file.endsWith('/wordpress_sites.yml') || file.endsWith('/wordpress_sites.yaml')) {
-      collectRegexMatches(content, [/^\s+db_name:\s*["']?([^"'#\s]+)/gim], siteNames)
-      collectRegexMatches(content, [/^\s+db_user:\s*["']?([^"'#\s]+)/gim], siteNames)
-      collectRegexMatches(content, [/^\s+web_user:\s*["']?([^"'#\s]+)/gim], siteNames)
+    const fileName = basename(file)
+    if (fileName !== 'wordpress_sites.yml' && fileName !== 'wordpress_sites.yaml') {
+      continue
     }
+
+    const content = readFileSync(file, 'utf8')
+    collectRegexMatches(content, [/^\s+db_name:\s*["']?([^"'#\s]+)/gim], siteNames)
+    collectRegexMatches(content, [/^\s+db_user:\s*["']?([^"'#\s]+)/gim], siteNames)
+    collectRegexMatches(content, [/^\s+web_user:\s*["']?([^"'#\s]+)/gim], siteNames)
   }
 
   const groupVarDirs = await globby([`${trellisRoot}/group_vars/*`], {

--- a/src/lib/trellis-kinsta.ts
+++ b/src/lib/trellis-kinsta.ts
@@ -29,9 +29,11 @@ export async function inferKinstaFromTrellis(cwd: string = process.cwd()): Promi
     }
 
     const content = readFileSync(file, 'utf8')
-    collectRegexMatches(content, [/^\s+db_name:\s*["']?([^"'#\s]+)/gim], siteNames)
-    collectRegexMatches(content, [/^\s+db_user:\s*["']?([^"'#\s]+)/gim], siteNames)
-    collectRegexMatches(content, [/^\s+web_user:\s*["']?([^"'#\s]+)/gim], siteNames)
+    collectRegexMatches(content, [
+      /^\s+db_name:\s*["']?([^"'#\s]+)/gim,
+      /^\s+db_user:\s*["']?([^"'#\s]+)/gim,
+      /^\s+web_user:\s*["']?([^"'#\s]+)/gim,
+    ], siteNames)
   }
 
   const groupVarDirs = await globby([`${trellisRoot}/group_vars/*`], {

--- a/src/lib/trellis-kinsta.ts
+++ b/src/lib/trellis-kinsta.ts
@@ -48,8 +48,8 @@ export async function inferKinstaFromTrellis(cwd: string = process.cwd()): Promi
   }
 
   return {
-    environmentNames: [...environmentNames],
-    siteNames: [...siteNames],
+    environmentNames: [...environmentNames].sort((a, b) => a.localeCompare(b)),
+    siteNames: [...siteNames].sort((a, b) => a.localeCompare(b)),
     trellisRoot,
   }
 }


### PR DESCRIPTION
## Summary

Adds a new `iroots kinsta env open` command to open a selected Kinsta site environment in the default browser, with Trellis-aware site inference and interactive selection improvements.

## Related

- N/A

## Changes

- Add `src/commands/kinsta/env/open.ts` for the new command with flag precedence, site/environment lookup, and interactive prompts.
- Add `src/lib/browser.ts` for cross-platform URL opening (`open`, `xdg-open`, `cmd /c start`) with explicit failure handling.
- Add `src/lib/trellis-kinsta.ts` to infer site candidates from Trellis `wordpress_sites.yml` using `db_name`, `db_user`, and `web_user`.
- Implement UX fixes: corrected Kinsta URL shape, alphabetically sorted selectors, environment metadata in site choices, and deterministic `--environment` matching priority.

## Testing

- `npm run lint`
- `npm run build`
