### PR TITLE
feat(kinsta-env): infer site from current directory on push

### DIFF
--- a/src/commands/kinsta/env/push.ts
+++ b/src/commands/kinsta/env/push.ts
@@ -3,6 +3,7 @@ import {Flags, ux} from '@oclif/core'
 import {KinstaCommand} from '../../../lib/commands/kinsta-command.js'
 import {findMatchingEnvironments, findMatchingSites, normalizeOptionalFlag, resolveEnvironment, resolveSite} from '../../../lib/kinsta-selectors.js'
 import {getAllSites, getSiteEnvironments, pushEnvironment} from '../../../lib/kinsta.js'
+import {inferKinstaFromTrellis} from '../../../lib/trellis-kinsta.js'
 
 type ResolveProgress = {
   start: (label: string) => void
@@ -18,6 +19,7 @@ type ResolvePushTargetIdsInput = {
   progress?: ResolveProgress
   site: string | undefined
   siteId: string | undefined
+  siteNameCandidates?: string[]
   sourceEnv: string | undefined
   sourceEnvId: string | undefined
   targetEnv: string | undefined
@@ -130,7 +132,7 @@ const resolveSiteAndEnvironments = async (
       throw new Error(`No Kinsta sites found for company "${company}"`)
     }
 
-    const selectedSite = await resolveSite(sites, compact([siteId, site]), site)
+    const selectedSite = await resolveSite(sites, compact([siteId, site, ...(input.siteNameCandidates ?? [])]), site)
     const selectedSiteId = selectedSite.id
     const preloadedEnvironments = selectedSite.environments ?? []
 
@@ -352,6 +354,12 @@ export default class Push extends KinstaCommand {
       required: false,
     }),
     // eslint-disable-next-line camelcase
+    infer_site: Flags.boolean({
+      allowNo: true,
+      default: true,
+      description: 'Infer the site from the current directory (Trellis/Bedrock). Use --no-infer_site to always pick from the full site list.',
+    }),
+    // eslint-disable-next-line camelcase
     push_db: Flags.boolean({
       allowNo: true,
       default: true,
@@ -391,9 +399,14 @@ export default class Push extends KinstaCommand {
   public async run(): Promise<void> {
     const {flags} = await this.parse(Push)
 
+    const siteFlag = normalizeOptionalFlag(flags.site)
     const siteIdFlag = normalizeOptionalFlag(flags.site_id)
     const sourceEnvIdFlag = normalizeOptionalFlag(flags.source_env_id)
     const targetEnvIdFlag = normalizeOptionalFlag(flags.target_env_id)
+
+    const inference = flags.infer_site && siteIdFlag === undefined && siteFlag === undefined
+      ? await inferKinstaFromTrellis(process.cwd())
+      : null
 
     let resolvedIds: ResolvePushTargetIdsOutput
 
@@ -406,6 +419,7 @@ export default class Push extends KinstaCommand {
         includeEnvironmentNames: true,
         site: flags.site,
         siteId: siteIdFlag,
+        siteNameCandidates: inference?.siteNames,
         sourceEnv: flags.source_env,
         sourceEnvId: sourceEnvIdFlag,
         targetEnv: flags.target_env,

--- a/tests/commands/kinsta/env/push-resolution.test.ts
+++ b/tests/commands/kinsta/env/push-resolution.test.ts
@@ -116,6 +116,90 @@ describe('env push resolution', () => {
     })
   })
 
+  it('auto-selects a site inferred from the current directory when unambiguous', async () => {
+    const resolved = await resolvePushTargetIds({
+      apiKey: 'api',
+      company: 'co',
+      async getAllSites() {
+        return [
+          {
+            company_id: 'co',
+            display_name: 'Affinia',
+            id: 'site-1',
+            name: 'affinia',
+          },
+          {
+            company_id: 'co',
+            display_name: 'Other Site',
+            id: 'site-2',
+            name: 'other-site',
+          }
+        ] as any
+      },
+      async getSiteEnvironments() {
+        return [
+          {display_name: 'Staging', id: 'env-1', name: 'staging'},
+          {display_name: 'Live', id: 'env-2', name: 'live'},
+        ] as any
+      },
+      site: undefined,
+      siteId: undefined,
+      siteNameCandidates: ['affinia'],
+      sourceEnv: 'Staging',
+      sourceEnvId: undefined,
+      targetEnv: 'Live',
+      targetEnvId: undefined,
+    })
+
+    expect(resolved).to.deep.equal({
+      siteId: 'site-1',
+      sourceEnvId: 'env-1',
+      targetEnvId: 'env-2',
+    })
+  })
+
+  it('prefers an explicit --site over inferred directory candidates when they conflict', async () => {
+    const resolved = await resolvePushTargetIds({
+      apiKey: 'api',
+      company: 'co',
+      async getAllSites() {
+        return [
+          {
+            company_id: 'co',
+            display_name: 'Affinia',
+            id: 'site-1',
+            name: 'affinia',
+          },
+          {
+            company_id: 'co',
+            display_name: 'Other Site',
+            id: 'site-2',
+            name: 'other-site',
+          }
+        ] as any
+      },
+      async getSiteEnvironments() {
+        return [
+          {display_name: 'Staging', id: 'env-1', name: 'staging'},
+          {display_name: 'Live', id: 'env-2', name: 'live'},
+        ] as any
+      },
+      site: 'Other Site',
+      siteId: undefined,
+      siteNameCandidates: ['affinia'],
+      sourceEnv: 'Staging',
+      sourceEnvId: undefined,
+      targetEnv: 'Live',
+      targetEnvId: undefined,
+    })
+
+    expect(resolved).to.deep.equal({
+      siteId: 'site-2',
+      sourceEnvId: 'env-1',
+      targetEnvId: 'env-2',
+    })
+  })
+
   it('fails with a company-specific error when no sites exist for the company', async () => {
     let message = ''
 


### PR DESCRIPTION
## Summary

Auto-selects the Kinsta site for `iroots kinsta env push` by inferring it from the current directory (Trellis/Bedrock project), instead of always prompting from the full site list.

## Related

- N/A

## Changes

- Wire the existing `inferKinstaFromTrellis` helper (already used by `kinsta env open`) into `kinsta env push`, threading inferred site name candidates through `resolvePushTargetIds`.
- Auto-select the site when exactly one candidate matches; fall back to the existing prompt when inference is ambiguous, unavailable, or an explicit `--site`/`--site_id` is provided.
- Add `--infer_site` (default `true`, `allowNo`) so `--no-infer_site` always shows the full site list, bypassing directory-based inference.
- Add tests covering auto-selection from inferred candidates and explicit `--site` taking priority over inference.

## Testing

- `npm run lint`
- `npm run build`
- `npm test`
- Manually verified `inferKinstaFromTrellis` resolves the same Trellis root and site name candidates from both a Bedrock and Trellis project directory.
